### PR TITLE
Finish raw query version

### DIFF
--- a/tasks.md
+++ b/tasks.md
@@ -1,6 +1,5 @@
 # To do
 
-* Write docstrings
 * Align parent and sibling classes
 * Add DataQueue functionality to parent class
 * Write tests for object time series database


### PR DESCRIPTION
All of the methods which communicate with Honeycomb are still really ugly. In my next pass, I'll clean these up and use the models and methods in the Honeycomb SDK wherever possible.

Only the methods for object time series database (e.g., measurement database) are implemented so far. Need to go back  and implement corresponding methods for object database (e.g., configuration database) and possibly for time series database (e.g. 2D poses that are not yet associated with a person).